### PR TITLE
Certs Functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ build:
 	@echo "Compilation done."
 	@echo "Run \"./build/bin/$(BIN_NAME) -h\" to view available commands."
 
+build-linux:
+	GOOS=linux GOARCH=amd64 go build -i -o $(GOBIN)/$(BIN_NAME)-linux -v .
+	@echo "Compilation done."
+	@echo "Run \"./build/bin/$(BIN_NAME) -h\" to view available commands."
+
 test:
 	go test -v ./...
 

--- a/certs.go
+++ b/certs.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	keycard "github.com/alex-miller-0/keycard-go"
+	"github.com/alex-miller-0/keycard-go/io"
+	"github.com/alex-miller-0/keycard-go/types"
+	"math/rand"
+)
+
+type Certifier struct {
+	c types.Channel
+}
+
+func NewCertifier(t io.Transmitter) *Certifier {
+	return &Certifier{
+		c: io.NewNormalChannel(t),
+	}
+}
+
+// Get the public key corresponding to the card's identity
+func (c *Certifier) GetId() ([]byte, error) {
+	// Send some random data to `authenticate` and get a signature template back
+	cmdSet := keycard.NewCommandSet(c.c)
+	challenge := make([]byte, 32)
+	rand.Read(challenge)
+	data, err := cmdSet.GenericCommand(0xEE, 0x00, 0x00, challenge)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := types.ParseSignature(challenge, data)
+	if err != nil {
+		return nil, err
+	}
+	return sig.PubKey(), nil
+}
+
+// Put a signature onto the card which contains the certs
+func (c *Certifier) PutCert(cert []byte) (error) {
+	cmdSet := keycard.NewCommandSet(c.c)
+	_, err := cmdSet.GenericCommand(0xFA, 0x00, 0x00, cert)
+	return err
+}
+
+// Get the cert from the card
+func (c *Certifier) GetCert() ([]byte, error) {
+	cmdSet := keycard.NewCommandSet(c.c)
+	data, err := cmdSet.GenericCommand(0xFB, 0x00, 0x00, []byte{})
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+

--- a/certs.go
+++ b/certs.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"errors"
 	keycard "github.com/alex-miller-0/keycard-go"
 	"github.com/alex-miller-0/keycard-go/io"
 	"github.com/alex-miller-0/keycard-go/types"
@@ -17,20 +19,27 @@ func NewCertifier(t io.Transmitter) *Certifier {
 	}
 }
 
+func (c *Certifier) Select() (error) {
+	cmdSet := keycard.NewCommandSet(c.c)
+	return cmdSet.Select()
+}
+
 // Get the public key corresponding to the card's identity
 func (c *Certifier) GetId() ([]byte, error) {
 	// Send some random data to `authenticate` and get a signature template back
 	cmdSet := keycard.NewCommandSet(c.c)
-	
+
 	challenge := make([]byte, 32)
 	rand.Read(challenge)
 	data, err := cmdSet.GenericCommand(0x00, 0xEE, 0x00, 0x00, challenge)
 	if err != nil {
 		return nil, err
 	}
+
 	sig, err := types.ParseSignature(challenge, data)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(fmt.Sprintf("Error parsing signature data: %x", data))
+	
 	}
 	return sig.PubKey(), nil
 }
@@ -45,7 +54,7 @@ func (c *Certifier) PutCert(cert []byte) (error) {
 // Get the cert from the card
 func (c *Certifier) GetCert() ([]byte, error) {
 	cmdSet := keycard.NewCommandSet(c.c)
-	data, err := cmdSet.GenericCommand(0x80, 0xFB, 0x00, 0x00, []byte{})
+	data, err := cmdSet.GenericCommand(0x80, 0xFB, 0x00, 0x00, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/certs.go
+++ b/certs.go
@@ -21,9 +21,10 @@ func NewCertifier(t io.Transmitter) *Certifier {
 func (c *Certifier) GetId() ([]byte, error) {
 	// Send some random data to `authenticate` and get a signature template back
 	cmdSet := keycard.NewCommandSet(c.c)
+	
 	challenge := make([]byte, 32)
 	rand.Read(challenge)
-	data, err := cmdSet.GenericCommand(0xEE, 0x00, 0x00, challenge)
+	data, err := cmdSet.GenericCommand(0x00, 0xEE, 0x00, 0x00, challenge)
 	if err != nil {
 		return nil, err
 	}
@@ -37,14 +38,14 @@ func (c *Certifier) GetId() ([]byte, error) {
 // Put a signature onto the card which contains the certs
 func (c *Certifier) PutCert(cert []byte) (error) {
 	cmdSet := keycard.NewCommandSet(c.c)
-	_, err := cmdSet.GenericCommand(0xFA, 0x00, 0x00, cert)
+	_, err := cmdSet.GenericCommand(0x80, 0xFA, 0x00, 0x00, cert)
 	return err
 }
 
 // Get the cert from the card
 func (c *Certifier) GetCert() ([]byte, error) {
 	cmdSet := keycard.NewCommandSet(c.c)
-	data, err := cmdSet.GenericCommand(0xFB, 0x00, 0x00, []byte{})
+	data, err := cmdSet.GenericCommand(0x80, 0xFB, 0x00, 0x00, []byte{})
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -257,8 +257,6 @@ func commandInfo(card *scard.Card) error {
 }
 
 func commandGetId(card *scard.Card) error {
-	fmt.Printf("len(os.args) %d\n", len(os.Args))
-	fmt.Printf("arg %s\n", os.Args[len(os.Args) - 1])
 	c := NewCertifier(card)
 	idPub, err := c.GetId()
 	if err != nil {
@@ -280,19 +278,32 @@ func commandCertify(card *scard.Card) error {
 		// This must be an [r,s] ECDSA signature
 		return errors.New("Your cert must be a 64 byte hex string")
 	}
-	fmt.Printf("Putting cert %v\n", cert)
-	// Push cert to card
 	c := NewCertifier(card)
+
+
+	fmt.Printf("Getting cert\n")
+	loadedCert, err := c.GetCert()
+	if err != nil {
+		fmt.Printf("Could not get cert\n")
+		return err
+	}
+	fmt.Printf("Got cert: %v\n", loadedCert)
+
+	// Push cert to card
+	fmt.Printf("Putting cert %v\n", cert);
 	err = c.PutCert(cert)
 	if err != nil {
 		return err
 	}
+	
 	// Ensure the cert was loaded
+	fmt.Printf("Getting cert\n")
 	data, err := c.GetCert()
+	fmt.Printf("Got cert: %v\n", data)
 	if err != nil {
 		return err
-	} else if !bytes.Equal(data, cert) {
-		return errors.New("Cert not propertly loaded to card")
+		} else if !bytes.Equal(data[2:], cert) {
+			return errors.New("Cert not propertly loaded to card")
 	}
 
 	return nil


### PR DESCRIPTION
Adds the ability to load a certificate. This utilizes SafeCard-specific APDUs to get an identity public key, load a cert, and export the cert

- [x] Get ID pubkey
- [x] Load cert
- [x] Export cert
- [x] Clean up commands and figure out how to do this with an uninitialized card